### PR TITLE
[resize-observer-1] attributes cannot be sequence<T> #4683

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -318,7 +318,7 @@ interface ResizeObservation {
     : <dfn>observedBox</dfn>
     :: Which box is being observed.
     : <dfn>lastReportedSizes</dfn>
-    :: Ordered frozen array of last reported sizes.
+    :: Ordered array of last reported sizes.
 </div>
 <div dfn-type="method" dfn-for="ResizeObservation">
     : <dfn constructor lt="ResizeObservation(target, options)">new ResizeObservation(target, observedBox)</dfn>

--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -309,7 +309,7 @@ interface ResizeObservation {
     constructor(Element target);
     readonly attribute Element target;
     readonly attribute ResizeObserverBoxOptions observedBox;
-    readonly attribute sequence&lt;ResizeObserverSize> lastReportedSizes;
+    readonly attribute FrozenArray&lt;ResizeObserverSize> lastReportedSizes;
 };
 </pre>
 <div dfn-type="attribute" dfn-for="ResizeObservation">
@@ -318,7 +318,7 @@ interface ResizeObservation {
     : <dfn>observedBox</dfn>
     :: Which box is being observed.
     : <dfn>lastReportedSizes</dfn>
-    :: Ordered sequence of last reported sizes.
+    :: Ordered frozen array of last reported sizes.
 </div>
 <div dfn-type="method" dfn-for="ResizeObservation">
     : <dfn constructor lt="ResizeObservation(target, options)">new ResizeObservation(target, observedBox)</dfn>


### PR DESCRIPTION
Fix invalid WebIDL by changing sequence<ResizeObserverSize> to FrozenArray<ResizeObserverSize> for lastReportedSizes in the ResizeObservation interface.
